### PR TITLE
Update ps-menu.psm1

### DIFF
--- a/ps-menu.psm1
+++ b/ps-menu.psm1
@@ -39,7 +39,7 @@ function Menu {
     $vkeycode = 0
     $pos = 0
     $selection = @()
-    $cur_pos = [System.Console]::CursorTop
+    $cur_pos = [System.Console]::get_CursorTop()
     [console]::CursorVisible=$false #prevents cursor flickering
     if ($menuItems.Length -gt 0)
 	{


### PR DESCRIPTION
On the main Menu function I've changed:
$cur_pos = [System.Console]::CursorTop
To:
$cur_pos = [System.Console]::get_CursorTop()
I suppose that was the original purpose of this variable. In the other form, it causes the menu to redraw itself below the original menu on every key pressed. 

Cheers!