### PR TITLE
Optimized for clarity & Implemented Columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,39 @@
 # PS-Menu
+
 Simple module to generate interactive console menus (like yeoman)
 
-# Examples:
+## Examples
 
-```powershell
+```ps
 menu @("option 1", "option 2", "option 3")
 ```
+
  ![Example](https://github.com/chrisseroka/ps-menu/raw/master/docs/example1.gif)
 
 More useful example:
 
  ![Example](https://github.com/chrisseroka/ps-menu/raw/master/docs/example2.gif)
 
-# Installation
+## Installation
 
 You can install it from the PowerShellGallery using PowerShellGet
 
-```powershell
+```ps
 Install-Module PS-Menu
 ```
-# Features
+
+## Features
 
 * Returns value of selected menu item
 * Returns index of selected menu item (using `-ReturnIndex` switch)
-* Navigation with `up/down` arrows
-* Navigation with `j/k` (vim style)
+* Displays the menu in multiple columns (using the `-Table` switch)
+* Navigation with `up/down/left/right` arrows
+* Navigation with `h/j/k/l` (vim style)
 * Esc key quits the menu (`null` value returned)
 
-# Contributing
+## Contributing
 
 * Source hosted at [GitHub][repo]
 * Report issues/questions/feature requests on [GitHub Issues][issues]
 
-Pull requests are very welcome! 
+Pull requests are very welcome!

--- a/ps-menu.psm1
+++ b/ps-menu.psm1
@@ -1,22 +1,28 @@
 function DrawMenu{
-    param ($menuItems, $menuPosition, $Multiselect, $selection, $columnCount)
+    param ($menuItems, $menuPosition, $Multiselect, $selection, $columnCount=$false)
 	$highLight = @{
 		ForegroundColor = [System.Console]::BackgroundColor
 		BackgroundColor = [System.Console]::ForegroundColor
 	}
 	if($columnCount){
+		$width = ($menuItems | Measure-Object -Property Length -Maximum).Maximum
 		for($i = 0; $i -le $menuItems.length;$i++){
-			if($menuItems[$i]){
+			$object = $menuItems[$i]
+			if($object){
+				$text = "$object$(" " * ($width - $object.Length))"
 				if($Multiselect -and $selection -contains $i){
-					$item = "[$($menuItems[$i])]"
+					$item = "[x] $text "
 				}else{
-					$item = " $($menuItems[$i]) "
+					$item = "[ ] $text "
 				}
 				if($i -eq $menuPosition){
-					Write-Host $item @highLight
+					Write-Host $item @highLight -NoNewline
 				}else{
-					Write-Host $item
+					Write-Host $item -NoNewline
 				}
+			}
+			if(-not (($i +1) % $columnCount)){
+				Write-Host ''
 			}
 		}
 	}else{
@@ -55,7 +61,7 @@ function Switch-Selection{
 }
 
 function Menu{
-    param([array]$menuItems,[switch]$ReturnIndex=$false,[switch]$Multiselect,[switch]$Table)
+    param([array]$menuItems,[switch]$ReturnIndex=$false,[switch]$Multiselect,[switch]$Table=$false)
     $keycode = 0
     $pos = 0
     $selection = @()
@@ -64,26 +70,39 @@ function Menu{
 			$keys = [PSCustomObject]@{ # Keycode list: https://learn.microsoft.com/en-us/dotnet/api/system.consolekey?view=net-9.0
 				up = 38,75		# Up arrow, k
 				down = 40,74	# Down arrow, j
-				left = 37		# Left arrow
-				right = 39		# Right arrow
+				left = 37,72	# Left arrow, h
+				right = 39,76	# Right arrow, l
 				home = 36		# Home key
 				end = 35		# End key
 				toggle = 32		# Space
 			}
 			if($Table){
-				$columnCount = [Math]::Floor([System.Console]::WindowWidth / (($menuItems | Measure-Object -Property Length -Maximum).Maximum +2))
+				$columnCount = [Math]::Floor([System.Console]::WindowWidth / (($menuItems | Measure-Object -Property Length -Maximum).Maximum +4))
+				$lineCount = [Math]::Ceiling($menuItems.Count / $columnCount)
 			}
 			$startPos = [System.Console]::CursorTop
 			[System.Console]::CursorVisible = $false #prevents cursor flickering
-			DrawMenu $menuItems $pos $Multiselect $selection
+			DrawMenu $menuItems $pos $Multiselect $selection $columnCount
 			While($keycode -ne 13 -and $keycode -ne 27){
 				$keycode = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown").VirtualKeyCode
-				switch($keycode){
-					{$keys.up -contains $_}{$pos--}
-					{$keys.down -contains $_}{$pos++}
-					{$keys.home -contains $_}{$pos = 0}
-					{$keys.end -contains $_}{$pos = $menuItems.length - 1}
-					{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
+				if($columnCount){
+					switch($keycode){
+						{$keys.up -contains $_ -and $lineCount -gt 1}{$pos = $pos - $columnCount}
+						{$keys.down -contains $_ -and $lineCount -gt 1}{$pos = $pos + $columnCount}
+						{$keys.left -contains $_}{$pos--}
+						{$keys.right -contains $_}{$pos++}
+						{$keys.home -contains $_}{$pos = 0}
+						{$keys.end -contains $_}{$pos = $menuItems.length - 1}
+						{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
+					}
+				}else{
+					switch($keycode){
+						{$keys.up -contains $_}{$pos--}
+						{$keys.down -contains $_}{$pos++}
+						{$keys.home -contains $_}{$pos = 0}
+						{$keys.end -contains $_}{$pos = $menuItems.length - 1}
+						{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
+					}
 				}
 				switch($pos){ # When attempting to move the cursor outside of the array
 					{$_ -lt 0}{$pos = 0}
@@ -92,13 +111,21 @@ function Menu{
 				if($keycode -eq 27){ # Esc key
 					$pos = $null
 				}else{
-					$startPos = [System.Console]::CursorTop - $menuItems.Length
+					if($columnCount){
+						$startPos = [System.Console]::CursorTop - $lineCount
+					}else{
+						$startPos = [System.Console]::CursorTop - $menuItems.Length
+					}
 					[System.Console]::SetCursorPosition(0, $startPos)
-					DrawMenu $menuItems $pos $Multiselect $selection
+					DrawMenu $menuItems $pos $Multiselect $selection $columnCount
 				}
 			}
 		}finally{
-			[System.Console]::SetCursorPosition(0, $startPos + $menuItems.Length)
+			if($columnCount){
+				[System.Console]::SetCursorPosition(0, $startPos + $lineCount)
+			}else{
+				[System.Console]::SetCursorPosition(0, $startPos + $menuItems.Length)
+			}
 			[System.Console]::CursorVisible = $true
 		}
 	}else{

--- a/ps-menu.psm1
+++ b/ps-menu.psm1
@@ -1,24 +1,24 @@
 function DrawMenu{
     param ($menuItems, $menuPosition, $Multiselect, $selection, $columnCount=$false)
-	$highLight = @{
-		ForegroundColor = [System.Console]::BackgroundColor
-		BackgroundColor = [System.Console]::ForegroundColor
-	}
 	if($columnCount){
-		$width = ($menuItems | Measure-Object -Property Length -Maximum).Maximum
+		$maxWidth = ($menuItems | Measure-Object -Property Length -Maximum).Maximum
 		for($i = 0; $i -le $menuItems.length;$i++){
 			$object = $menuItems[$i]
 			if($object){
-				$text = "$object$(" " * ($width - $object.Length))"
-				if($Multiselect -and $selection -contains $i){
-					$item = "[x] $text "
+				$text = "$object$(" " * ($maxWidth - $object.Length))"
+				if($Multiselect){
+					if($selection -contains $i){
+					$item = "[x] $text"
+					}else{
+						$item = "[ ] $text"
+					}
 				}else{
-					$item = "[ ] $text "
+					$item = "  $text  "
 				}
 				if($i -eq $menuPosition){
-					Write-Host $item @highLight -NoNewline
+					Write-Host ">$item<" -ForegroundColor Green -NoNewline
 				}else{
-					Write-Host $item -NoNewline
+					Write-Host " $item " -NoNewline
 				}
 			}
 			if(-not (($i +1) % $columnCount)){
@@ -27,8 +27,8 @@ function DrawMenu{
 		}
 	}else{
 		for($i = 0; $i -le $menuItems.length;$i++){
-			if($null -ne $menuItems[$i]){
-				$item = $menuItems[$i]
+			$item = $menuItems[$i]
+			if($item){
 				if($Multiselect)
 				{
 					if($selection -contains $i){
@@ -77,32 +77,29 @@ function Menu{
 				toggle = 32		# Space
 			}
 			if($Table){
-				$columnCount = [Math]::Floor([System.Console]::WindowWidth / (($menuItems | Measure-Object -Property Length -Maximum).Maximum +4))
-				$lineCount = [Math]::Ceiling($menuItems.Count / $columnCount)
+				try{
+					$columnCount = [Math]::Floor([System.Console]::WindowWidth / (($menuItems | Measure-Object -Property Length -Maximum -ErrorAction Stop).Maximum +6))
+					$lineCount = [Math]::Ceiling($menuItems.Count / $columnCount)
+				}catch{ # If the array objects cannot be measured.
+					$columnCount = 0
+					$lineCount = 0
+				}
 			}
 			$startPos = [System.Console]::CursorTop
 			[System.Console]::CursorVisible = $false #prevents cursor flickering
 			DrawMenu $menuItems $pos $Multiselect $selection $columnCount
 			While($keycode -ne 13 -and $keycode -ne 27){
 				$keycode = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown").VirtualKeyCode
-				if($columnCount){
-					switch($keycode){
-						{$keys.up -contains $_ -and $lineCount -gt 1}{$pos = $pos - $columnCount}
-						{$keys.down -contains $_ -and $lineCount -gt 1}{$pos = $pos + $columnCount}
-						{$keys.left -contains $_}{$pos--}
-						{$keys.right -contains $_}{$pos++}
-						{$keys.home -contains $_}{$pos = 0}
-						{$keys.end -contains $_}{$pos = $menuItems.length - 1}
-						{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
-					}
-				}else{
-					switch($keycode){
-						{$keys.up -contains $_}{$pos--}
-						{$keys.down -contains $_}{$pos++}
-						{$keys.home -contains $_}{$pos = 0}
-						{$keys.end -contains $_}{$pos = $menuItems.length - 1}
-						{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
-					}
+				switch($keycode){
+					{$keys.up -contains $_ -and $lineCount -gt 1}{$pos = $pos - $columnCount}
+					{$keys.down -contains $_ -and $lineCount -gt 1}{$pos = $pos + $columnCount}
+					{$keys.up -contains $_ -and -not $columnCount}{$pos--}
+					{$keys.down -contains $_ -and -not $columnCount}{$pos++}
+					{$keys.left -contains $_}{$pos--}
+					{$keys.right -contains $_}{$pos++}
+					{$keys.home -contains $_}{$pos = 0}
+					{$keys.end -contains $_}{$pos = $menuItems.length - 1}
+					{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
 				}
 				switch($pos){ # When attempting to move the cursor outside of the array
 					{$_ -lt 0}{$pos = 0}
@@ -142,5 +139,53 @@ function Menu{
 			return $menuItems[$selection]
 		}
 	}
+
+		
+	<#
+	.SYNOPSIS
+		Displays the menu items, returning the chosen items to the user.
+
+	.DESCRIPTION
+		Displays the given menu items, allowing the user to choose the
+		outputted item(s) by navigating the menu using the arrow keys and
+		validating their selection with the "Enter" key.
+		The "Esc" key will close the menu, returning nothing.
+
+	.PARAMETER menuItems
+		Array containing the items that are to be shown.
+
+	.PARAMETER Multiselect
+		Will allow multiple items to be selected from the displayed menu.
+		Adding an items to the selection is done using the space-bar.
+
+	.PARAMETER ReturnIndex
+		Will return the index of the selected item(s) instead of the item
+		itself.
+	
+	.PARAMETER Table
+		Will display the given items in columns, if the space of the current
+		host window allows for it.
+
+	.EXAMPLE
+		menu @("option 1", "option 2", "option 3")
+
+	.EXAMPLE
+		menu (gci) -MultiSelect
+
+	.EXAMPLE
+		menu (Get-LocalUser).Name -MultiSelect -Table -ReturnIndex
+
+	.INPUTS
+		None. You cannot pipe data into "menu".
+
+	.OUTPUTS
+		The selected menu item(s) or their index.
+
+	.LINK
+		[System.Console]::SetCursorPosition
+
+	.LINK
+		[System.Console]::CursorTop
+	#>
 }
 

--- a/ps-menu.psm1
+++ b/ps-menu.psm1
@@ -1,24 +1,45 @@
 function DrawMenu{
-    param ($menuItems, $menuPosition, $Multiselect, $selection)
-    for($i = 0; $i -le $menuItems.length;$i++){
-		if($null -ne $menuItems[$i]){
-			$item = $menuItems[$i]
-			if($Multiselect)
-			{
-				if($selection -contains $i){
-					$item = '[x] ' + $item
+    param ($menuItems, $menuPosition, $Multiselect, $selection, $columnCount)
+	$highLight = @{
+		ForegroundColor = [System.Console]::BackgroundColor
+		BackgroundColor = [System.Console]::ForegroundColor
+	}
+	if($columnCount){
+		for($i = 0; $i -le $menuItems.length;$i++){
+			if($menuItems[$i]){
+				if($Multiselect -and $selection -contains $i){
+					$item = "[$($menuItems[$i])]"
+				}else{
+					$item = " $($menuItems[$i]) "
 				}
-				else{
-					$item = '[ ] ' + $item
+				if($i -eq $menuPosition){
+					Write-Host $item @highLight
+				}else{
+					Write-Host $item
 				}
-			}
-			if($i -eq $menuPosition){
-				Write-Host "> $($item)" -ForegroundColor Green
-			}else{
-				Write-Host "  $($item)"
 			}
 		}
-    }
+	}else{
+		for($i = 0; $i -le $menuItems.length;$i++){
+			if($null -ne $menuItems[$i]){
+				$item = $menuItems[$i]
+				if($Multiselect)
+				{
+					if($selection -contains $i){
+						$item = '[x] ' + $item
+					}
+					else{
+						$item = '[ ] ' + $item
+					}
+				}
+				if($i -eq $menuPosition){
+					Write-Host "> $($item)" -ForegroundColor Green
+				}else{
+					Write-Host "  $($item)"
+				}
+			}
+		}
+	}
 }
 
 function Switch-Selection{
@@ -34,7 +55,7 @@ function Switch-Selection{
 }
 
 function Menu{
-    param([array]$menuItems,[switch]$ReturnIndex=$false,[switch]$Multiselect)
+    param([array]$menuItems,[switch]$ReturnIndex=$false,[switch]$Multiselect,[switch]$Table)
     $keycode = 0
     $pos = 0
     $selection = @()
@@ -43,11 +64,16 @@ function Menu{
 			$keys = [PSCustomObject]@{ # Keycode list: https://learn.microsoft.com/en-us/dotnet/api/system.consolekey?view=net-9.0
 				up = 38,75		# Up arrow, k
 				down = 40,74	# Down arrow, j
+				left = 37		# Left arrow
+				right = 39		# Right arrow
 				home = 36		# Home key
 				end = 35		# End key
 				toggle = 32		# Space
 			}
-			$startPos = [System.Console]::CursorTop		
+			if($Table){
+				$columnCount = [Math]::Floor([System.Console]::WindowWidth / (($menuItems | Measure-Object -Property Length -Maximum).Maximum +2))
+			}
+			$startPos = [System.Console]::CursorTop
 			[System.Console]::CursorVisible = $false #prevents cursor flickering
 			DrawMenu $menuItems $pos $Multiselect $selection
 			While($keycode -ne 13 -and $keycode -ne 27){

--- a/ps-menu.psm1
+++ b/ps-menu.psm1
@@ -1,94 +1,92 @@
-function DrawMenu {
+function DrawMenu{
     param ($menuItems, $menuPosition, $Multiselect, $selection)
-    $l = $menuItems.length
-    for ($i = 0; $i -le $l;$i++) {
-		if ($menuItems[$i] -ne $null){
+    for($i = 0; $i -le $menuItems.length;$i++){
+		if($null -ne $menuItems[$i]){
 			$item = $menuItems[$i]
-			if ($Multiselect)
+			if($Multiselect)
 			{
-				if ($selection -contains $i){
+				if($selection -contains $i){
 					$item = '[x] ' + $item
 				}
-				else {
+				else{
 					$item = '[ ] ' + $item
 				}
 			}
-			if ($i -eq $menuPosition) {
+			if($i -eq $menuPosition){
 				Write-Host "> $($item)" -ForegroundColor Green
-			} else {
+			}else{
 				Write-Host "  $($item)"
 			}
 		}
     }
 }
 
-function Toggle-Selection {
-	param ($pos, [array]$selection)
-	if ($selection -contains $pos){ 
-		$result = $selection | where {$_ -ne $pos}
+function Switch-Selection{
+	param($pos,[array]$selection)
+	if($selection -contains $pos){ 
+		$result = $selection | Where-Object{$_ -ne $pos}
 	}
-	else {
+	else{
 		$selection += $pos
 		$result = $selection
 	}
 	$result
 }
 
-function Menu {
-    param ([array]$menuItems, [switch]$ReturnIndex=$false, [switch]$Multiselect)
-    $vkeycode = 0
+function Menu{
+    param([array]$menuItems,[switch]$ReturnIndex=$false,[switch]$Multiselect)
+    $keycode = 0
     $pos = 0
     $selection = @()
-    if ($menuItems.Length -gt 0)
-	{
-		try {
+    if($menuItems.Length -gt 0){
+		try{
+			$keys = [PSCustomObject]@{ # Keycode list: https://learn.microsoft.com/en-us/dotnet/api/system.consolekey?view=net-9.0
+				up = 38,75		# Up arrow, k
+				down = 40,74	# Down arrow, j
+				home = 36		# Home key
+				end = 35		# End key
+				toggle = 32		# Space
+			}
 			$startPos = [System.Console]::CursorTop		
-			[console]::CursorVisible=$false #prevents cursor flickering
+			[System.Console]::CursorVisible = $false #prevents cursor flickering
 			DrawMenu $menuItems $pos $Multiselect $selection
-			While ($vkeycode -ne 13 -and $vkeycode -ne 27) {
-				$press = $host.ui.rawui.readkey("NoEcho,IncludeKeyDown")
-				$vkeycode = $press.virtualkeycode
-				If ($vkeycode -eq 38 -or $press.Character -eq 'k') {$pos--}
-				If ($vkeycode -eq 40 -or $press.Character -eq 'j') {$pos++}
-				If ($vkeycode -eq 36) { $pos = 0 }
-				If ($vkeycode -eq 35) { $pos = $menuItems.length - 1 }
-				If ($press.Character -eq ' ') { $selection = Toggle-Selection $pos $selection }
-				if ($pos -lt 0) {$pos = 0}
-				If ($vkeycode -eq 27) {$pos = $null }
-				if ($pos -ge $menuItems.length) {$pos = $menuItems.length -1}
-				if ($vkeycode -ne 27)
-				{
+			While($keycode -ne 13 -and $keycode -ne 27){
+				$keycode = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown").VirtualKeyCode
+				switch($keycode){
+					{$keys.up -contains $_}{$pos--}
+					{$keys.down -contains $_}{$pos++}
+					{$keys.home -contains $_}{$pos = 0}
+					{$keys.end -contains $_}{$pos = $menuItems.length - 1}
+					{$keys.toggle -contains $_}{$selection = Switch-Selection $pos $selection}
+				}
+				switch($pos){ # When attempting to move the cursor outside of the array
+					{$_ -lt 0}{$pos = 0}
+					{$_ -ge $menuItems.length}{$pos = $menuItems.length -1}
+				}
+				if($keycode -eq 27){ # Esc key
+					$pos = $null
+				}else{
 					$startPos = [System.Console]::CursorTop - $menuItems.Length
 					[System.Console]::SetCursorPosition(0, $startPos)
 					DrawMenu $menuItems $pos $Multiselect $selection
 				}
 			}
-		}
-		finally {
+		}finally{
 			[System.Console]::SetCursorPosition(0, $startPos + $menuItems.Length)
-			[console]::CursorVisible = $true
+			[System.Console]::CursorVisible = $true
 		}
-	}
-	else {
+	}else{
 		$pos = $null
 	}
 
-    if ($ReturnIndex -eq $false -and $pos -ne $null)
-	{
-		if ($Multiselect){
-			return $menuItems[$selection]
+	if($pos){
+		if(-not $Multiselect){
+			$selection = $pos
 		}
-		else {
-			return $menuItems[$pos]
-		}
-	}
-	else 
-	{
-		if ($Multiselect){
+		if($ReturnIndex){
 			return $selection
-		}
-		else {
-			return $pos
+		}else{
+			return $menuItems[$selection]
 		}
 	}
 }


### PR DESCRIPTION
Removed unused variables.
Grouped key codes in a single variable.
Replaced multiple if-statements with switches.
Cleaned up return part.
Renamed `Toggle-Selection` to `Switch-Selection`, in compliance with [Microsoft verb guidelines](https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-7.5).